### PR TITLE
Add Column for Initial Size of TempDB

### DIFF
--- a/sp_CheckTempdb.sql
+++ b/sp_CheckTempdb.sql
@@ -205,6 +205,7 @@ IF @Mode IN (1,99) BEGIN
         , FileType NVARCHAR(60)
         , [Filegroup] SYSNAME
         , SizeInMB INT
+		, InitialSizeInMB INT
         , Autogrowth NVARCHAR(20)
         , MaxSize NVARCHAR(50)
         , PhysicalName NVARCHAR(260)
@@ -217,6 +218,7 @@ IF @Mode IN (1,99) BEGIN
         , f.[type_desc]
         , COALESCE(g.[name], 'Not Applicable')
         , f.[size]/128
+		, mf.[size]/128
         , CASE f.[growth]
             WHEN 0 THEN 'None'
             ELSE CASE f.[is_percent_growth]
@@ -235,7 +237,10 @@ IF @Mode IN (1,99) BEGIN
         , f.[Physical_Name]
     FROM tempdb.sys.database_files f
     LEFT JOIN tempdb.sys.filegroups g
-        ON f.data_space_id = g.data_space_id;
+        ON f.data_space_id = g.data_space_id
+	LEFT JOIN tempdb.sys.master_files mf
+		ON mf.[file_id] = f.[file_id]
+		AND mf.database_id = 2;
     
     SELECT *
     FROM #Properties


### PR DESCRIPTION
Adding an additional column to show the initial size of tempdb so you can see the size used at startup and if it has grown from that.
<img width="886" height="132" alt="image" src="https://github.com/user-attachments/assets/40561d6d-d39e-46d4-adbb-965ba2f212ca" />